### PR TITLE
chore: set access-qa-bot version to latest compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
     "@preact/compat": "^18.3.1",
-    "@snf/access-qa-bot": "2.1.0",
+    "@snf/access-qa-bot": "^2.1.0",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "preact": "^10.24.1",


### PR DESCRIPTION
This updates the package.json so that the `@snf/access-qa-bot` package will always pull the latest compatible version. 

Previously we had it pinned to an exact version because we were iterating on major intial changes. 