### PR TITLE
Update @snf/access-qa-bot to 2.3.1-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
         "@preact/compat": "^18.3.1",
-        "@snf/access-qa-bot": "^2.3.0-beta.1",
+        "@snf/access-qa-bot": "^2.3.1-beta.1",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "preact": "^10.24.1",
@@ -1238,9 +1238,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "2.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-2.3.0-beta.1.tgz",
-      "integrity": "sha512-+R8RRHwtm7YZqfOeKkqeSpNW1uij9lTXoW5Wv8k9fMQB1bRg78JRDGBG2zv/qIuditEXfdZ7KuZCjjib8EWTwQ==",
+      "version": "2.3.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-2.3.1-beta.1.tgz",
+      "integrity": "sha512-sHg0pfR8nQq7p0CnPJBdsAPSyrAPqI5Na14ovz5u0z3Et/znpfqzc8cHdpR50qkAEwEMAVgoPtwsAYB2F0LNuQ==",
       "dependencies": {
         "@rcb-plugins/html-renderer": "^0.3.1",
         "@rcb-plugins/input-validator": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
     "@preact/compat": "^18.3.1",
-    "@snf/access-qa-bot": "^2.3.0-beta.1",
+    "@snf/access-qa-bot": "^2.3.1-beta.1",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "preact": "^10.24.1",


### PR DESCRIPTION
This updates the QABot to 2.3.1-beta.1, which includes latest functionality without the feedback flow. 