### PR TITLE
chore: update @snf/access-qa-bot from 2.6.2 to 2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^2.6.2",
+        "@snf/access-qa-bot": "^2.6.4",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.1.0",
@@ -1307,9 +1307,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-2.6.2.tgz",
-      "integrity": "sha512-51RyeRSb+Ad4YYwC0099R0v/chDzfy+Ggsu3ae315ShZUL01ZwYzIxcwQdIh5p5r3Thw9cPx3Wdd/jDJhMLsLw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-2.6.4.tgz",
+      "integrity": "sha512-m0ULu4cKkouO3xQsN3z9L3W2LNsLfH8QvPrKu3GciN+Jvnil32vleuFWP2XlyWTPrv3m1Yo+JbeaBvpNVf10Eg==",
       "dependencies": {
         "@rcb-plugins/html-renderer": "^0.3.1",
         "@rcb-plugins/input-validator": "^0.3.0",
@@ -4766,9 +4766,9 @@
       "optional": true
     },
     "@snf/access-qa-bot": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-2.6.2.tgz",
-      "integrity": "sha512-51RyeRSb+Ad4YYwC0099R0v/chDzfy+Ggsu3ae315ShZUL01ZwYzIxcwQdIh5p5r3Thw9cPx3Wdd/jDJhMLsLw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-2.6.4.tgz",
+      "integrity": "sha512-m0ULu4cKkouO3xQsN3z9L3W2LNsLfH8QvPrKu3GciN+Jvnil32vleuFWP2XlyWTPrv3m1Yo+JbeaBvpNVf10Eg==",
       "requires": {
         "@rcb-plugins/html-renderer": "^0.3.1",
         "@rcb-plugins/input-validator": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^2.6.2",
+    "@snf/access-qa-bot": "^2.6.4",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.1.0",


### PR DESCRIPTION
This updates the @snf/access-qa-bot package, which includes the following: 
- Changed default height of chatbot to be taller, with a maximum of 80% of the viewport
- Correctly formats hyperlinks in responses from the AI models
- Cleans up dead code