### PR TITLE
feat: resourceContext prop for resource scoping (F.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^3.1.1",
+        "@snf/access-qa-bot": "^3.5.0-rc.1",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.1.0",
@@ -1308,34 +1308,34 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.1.1.tgz",
-      "integrity": "sha512-oDXQ5+8tHLAuU/LpY23lpfFntPhMaGbnzL9grmvnhcDcLidgyT/8ZL3mDG8cMve+9mti64Dzk7ryPXhAR/lQ9A==",
+      "version": "3.5.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.5.0-rc.1.tgz",
+      "integrity": "sha512-ok6d1sUROQ4EiTZ4rxAm2q6vguflTPi7hAou3Jwyz//XsY7zfb1Qp5173qbczvsYRDbsIJXoNh95gfgWj9DECw==",
       "license": "MIT",
       "dependencies": {
-        "@snf/qa-bot-core": "^0.2.18",
+        "@snf/qa-bot-core": "^0.2.32-rc.1",
         "react-chatbotify": "^2.0.0",
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@snf/qa-bot-core": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@snf/qa-bot-core/-/qa-bot-core-0.2.18.tgz",
-      "integrity": "sha512-kw/chVb6P5df/APVSypSRziN2e4MDRwnhziQvWt9mG3qqzmVREVoAsiHQdsiTooAi+zo8OvaFg2kCoBoOPYjlQ==",
+      "version": "0.2.32-rc.1",
+      "resolved": "https://registry.npmjs.org/@snf/qa-bot-core/-/qa-bot-core-0.2.32-rc.1.tgz",
+      "integrity": "sha512-Z3Ta+N/5XSmGzKSd2O4S4IDpuXS5W/d+yr4sexL256Xl9AlvdrEl9plG4PZFgaMcF+POBHsmayYDXDykR0iiTQ==",
       "dependencies": {
         "@rcb-plugins/html-renderer": "^0.3.1",
         "@rcb-plugins/input-validator": "^0.3.0",
         "@rcb-plugins/markdown-renderer": "^0.3.1",
-        "react-chatbotify": "^2.2.0",
+        "react-chatbotify": "^2.5.0",
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1380,9 +1380,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -2563,9 +2563,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4776,24 +4776,24 @@
       "optional": true
     },
     "@snf/access-qa-bot": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.1.1.tgz",
-      "integrity": "sha512-oDXQ5+8tHLAuU/LpY23lpfFntPhMaGbnzL9grmvnhcDcLidgyT/8ZL3mDG8cMve+9mti64Dzk7ryPXhAR/lQ9A==",
+      "version": "3.5.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.5.0-rc.1.tgz",
+      "integrity": "sha512-ok6d1sUROQ4EiTZ4rxAm2q6vguflTPi7hAou3Jwyz//XsY7zfb1Qp5173qbczvsYRDbsIJXoNh95gfgWj9DECw==",
       "requires": {
-        "@snf/qa-bot-core": "^0.2.18",
+        "@snf/qa-bot-core": "^0.2.32-rc.1",
         "react-chatbotify": "^2.0.0",
         "uuid": "^11.1.0"
       }
     },
     "@snf/qa-bot-core": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@snf/qa-bot-core/-/qa-bot-core-0.2.18.tgz",
-      "integrity": "sha512-kw/chVb6P5df/APVSypSRziN2e4MDRwnhziQvWt9mG3qqzmVREVoAsiHQdsiTooAi+zo8OvaFg2kCoBoOPYjlQ==",
+      "version": "0.2.32-rc.1",
+      "resolved": "https://registry.npmjs.org/@snf/qa-bot-core/-/qa-bot-core-0.2.32-rc.1.tgz",
+      "integrity": "sha512-Z3Ta+N/5XSmGzKSd2O4S4IDpuXS5W/d+yr4sexL256Xl9AlvdrEl9plG4PZFgaMcF+POBHsmayYDXDykR0iiTQ==",
       "requires": {
         "@rcb-plugins/html-renderer": "^0.3.1",
         "@rcb-plugins/input-validator": "^0.3.0",
         "@rcb-plugins/markdown-renderer": "^0.3.1",
-        "react-chatbotify": "^2.2.0",
+        "react-chatbotify": "^2.5.0",
         "uuid": "^11.1.0"
       }
     },
@@ -4839,9 +4839,9 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "requires": {
         "@types/ms": "*"
       }
@@ -5648,9 +5648,9 @@
       }
     },
     "mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "requires": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^3.1.1",
-    "react-chatbotify": "^2.0.0",
+    "@snf/access-qa-bot": "^3.5.0-rc.1",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.1.0",
+    "react-chatbotify": "^2.0.0",
     "react-dom": "^18.1.0",
     "react-error-boundary": "^6.0.0",
     "react-router": "^7.7.1",

--- a/src/qa-bot.jsx
+++ b/src/qa-bot.jsx
@@ -20,6 +20,7 @@ export class QABot extends Component {
       userEmail,
       userName,
       accessId,
+      resourceContext,
       onAnalyticsEvent
     } = this.props;
 
@@ -50,6 +51,7 @@ export class QABot extends Component {
           userEmail={userEmail}
           userName={userName}
           accessId={accessId}
+          resourceContext={resourceContext}
           onAnalyticsEvent={onAnalyticsEvent}
         />
       </ErrorBoundary>

--- a/src/qa-bot.jsx
+++ b/src/qa-bot.jsx
@@ -41,7 +41,7 @@ export class QABot extends Component {
     return (
       <ErrorBoundary>
         <AsyncLoadedQABot
-          welcome={welcome || "Welcome to ACCESS Q&A Bot!"}
+          welcome={welcome}
           isLoggedIn={loggedIn}
           open={open}
           onOpenChange={onOpenChange}


### PR DESCRIPTION
## Summary

- Add explicit `resourceContext` prop to `QABot` wrapper component (destructure + passthrough)
- Bump `@snf/access-qa-bot` to `^3.5.0-rc.1` (includes resource scoping support)

When `resourceContext` is set (e.g. `"delta"`), the bot fetches RP-scoped capabilities and includes `resource_context` in query POST bodies for scoped RAG answers.

The prop flows through: `headerfooter.js` → `qaBot()` (spread) → `QABot` (explicit) → `AccessQABot` → `QABot (core)` → agent API.

## Companion PRs

- necyberteam/access-agent#13 — agent infrastructure (capabilities endpoint, UKY client, RPSectionCache)
- necyberteam/qa-bot-core#13 — `resourceContext` prop + POST body
- necyberteam/access-qa-bot#8 — passthrough + capabilities fetch URL

## Drupal integration (not in this PR)

- `headerfooter.js`: read `data-resource-context` from `.embedded-qa-bot` div, pass as `resourceContext`
- RP documentation template: add `data-resource-context="<slug>"` attribute to embedded bot div

## Test plan

- [x] Build passes (`npm run build`)
- [x] Verified end-to-end in local Drupal (ddev): embedded bot with hardcoded `resourceContext="delta"` → scoped capabilities + scoped RAG with fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)