### PR TITLE
chore: bump access-qa-bot to ^3.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^3.5.0",
+        "@snf/access-qa-bot": "^3.5.2",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.1.0",
@@ -1446,12 +1446,12 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.5.0.tgz",
-      "integrity": "sha512-CWbVSV+Y0BszRL+ONVdI6WNev3HaIJjx504kgNzyIppuSfgFL/kr15GLjdtWNHS6DcOEXWXYxeKflkHLe6AzQw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.5.2.tgz",
+      "integrity": "sha512-DQgm+VE+tygWEaFyqwMMj0eMVaGihYHmLJzlzT1G7KnsP2iLYKdVhWRpP4xWj/PzZqFnBrW2YrMYlTYXlLKhmg==",
       "license": "MIT",
       "dependencies": {
-        "@snf/qa-bot-core": "^0.2.32",
+        "@snf/qa-bot-core": "^0.2.35",
         "react-chatbotify": "^2.0.0",
         "uuid": "^11.1.0"
       },
@@ -1461,9 +1461,9 @@
       }
     },
     "node_modules/@snf/qa-bot-core": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@snf/qa-bot-core/-/qa-bot-core-0.2.32.tgz",
-      "integrity": "sha512-nf05VPZlLYw9dRYTa7mJhroYsXsLMUD/HpC7rIIDdrl1T0PUuRrESITr+i3YMprAIj6ORkkwgQiA8N7nU3oC3A==",
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@snf/qa-bot-core/-/qa-bot-core-0.2.35.tgz",
+      "integrity": "sha512-mfvFofXOIPCmR/6QwJDW0p5AemDrMrLOaY0Pznkkmaq9nZCEqrM42L+i52AGrBhOtFx68F0Rb3RZTX+vyzRM7g==",
       "dependencies": {
         "@rcb-plugins/html-renderer": "^0.3.1",
         "@rcb-plugins/input-validator": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^3.5.0",
+    "@snf/access-qa-bot": "^3.5.2",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.1.0",


### PR DESCRIPTION
## Summary
- Bumps `@snf/access-qa-bot` from `^3.5.0` to `^3.5.2`
- Picks up qa-bot-core 0.2.35 with Turnstile fixes (token reset, timeout removal, conditional login link)

## Test plan
- [ ] Tested locally via Drupal — bot works, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)