### PR TITLE
fix: bump @snf/access-qa-bot to 3.7.4 (agent-enabled chatbot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@access-ci/ui",
-  "version": "0.20.6",
+  "version": "0.20.7-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@access-ci/ui",
-      "version": "0.20.6",
+      "version": "0.20.7-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^3.7.3",
+        "@snf/access-qa-bot": "3.7.4-rc.0",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -1446,9 +1446,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.3.tgz",
-      "integrity": "sha512-pM7/5V6/hkK9wO3DfKQ4GljduEvkr7lYueg/TBC19wZa4AiSxoaJRA7XeT5Cp3QtckQTy48KbOVlo2yeIZjkIw==",
+      "version": "3.7.4-rc.0",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.4-rc.0.tgz",
+      "integrity": "sha512-d6zM7i0vOMKfWt5N4s29oXMTWUPYwsrl0TMRc6vwsbWTQRmb5UkHTvNbZfOWQPdC1EQ5jMLiz0T/f9MgxCo50Q==",
       "license": "MIT",
       "dependencies": {
         "@snf/qa-bot-core": "^0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@access-ci/ui",
-  "version": "0.20.7-rc.0",
+  "version": "0.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@access-ci/ui",
-      "version": "0.20.7-rc.0",
+      "version": "0.20.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "3.7.4-rc.0",
+        "@snf/access-qa-bot": "^3.7.4",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -1446,9 +1446,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.7.4-rc.0",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.4-rc.0.tgz",
-      "integrity": "sha512-d6zM7i0vOMKfWt5N4s29oXMTWUPYwsrl0TMRc6vwsbWTQRmb5UkHTvNbZfOWQPdC1EQ5jMLiz0T/f9MgxCo50Q==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.4.tgz",
+      "integrity": "sha512-odirArXDyiPTcW0Ui1726MKRVi9qdA8rONSf3UH9UWQQPqTetljDiO0hOH2Q6WY36BUEND75NAYmr2Zg2r1oPA==",
       "license": "MIT",
       "dependencies": {
         "@snf/qa-bot-core": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@access-ci/ui",
-  "version": "0.20.6",
+  "version": "0.20.7-rc.0",
   "description": "User interface components for ACCESS CI",
   "repository": "github:access-ci-org/access-ci-ui",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^3.7.3",
+    "@snf/access-qa-bot": "3.7.4-rc.0",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.0.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@access-ci/ui",
-  "version": "0.20.7-rc.0",
+  "version": "0.20.6",
   "description": "User interface components for ACCESS CI",
   "repository": "github:access-ci-org/access-ci-ui",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "3.7.4-rc.0",
+    "@snf/access-qa-bot": "^3.7.4",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
Wires the agent-enabled chatbot into the UI kit so the access-agent can be tested end-to-end on the test Drupal.

## What changed
- `@snf/access-qa-bot` `^3.7.3` → `^3.7.4`

3.7.4 removes the `AGENT_ENABLED` flag (chatbot always calls the agent) and bakes the prod agent endpoint (`https://qa.access-ci.org/api/v1`) into the build.

## Release / safety
- Merging triggers release-please → publishes `@access-ci/ui@0.20.7` to npm.
- **Production is unaffected.** `support.access-ci.org` is pinned to an exact `@access-ci/ui@0.20.5` via unpkg; publishing a new version does not move that pin. Prod only changes when its `headerfooter.js` pin is deliberately bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)