### PR TITLE
fix: bump @snf/access-qa-bot to 3.7.5 (agentic menu restore)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^3.7.4",
+        "@snf/access-qa-bot": "^3.7.5",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -1446,9 +1446,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.4.tgz",
-      "integrity": "sha512-odirArXDyiPTcW0Ui1726MKRVi9qdA8rONSf3UH9UWQQPqTetljDiO0hOH2Q6WY36BUEND75NAYmr2Zg2r1oPA==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.5.tgz",
+      "integrity": "sha512-uAL56oLulzdOhBsL9Ac/EKBN6YyR0sy5tg/LMh6XYEjTKfxRiXDwwAGx92fFxom5n3EHWCNXPGIbEEDRPTmLkQ==",
       "license": "MIT",
       "dependencies": {
         "@snf/qa-bot-core": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^3.7.4",
+    "@snf/access-qa-bot": "^3.7.5",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
Bumps the chatbot to 3.7.5, which restores the single "Show my options" agent menu (removes the static ticket/security/metrics buttons left over from the agent enable). Merging publishes `@access-ci/ui@0.20.8` via release-please. Production pin (`0.20.5`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)