### PR TITLE
fix: pin @snf/access-qa-bot to 3.7.3 (keep agent build off latest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^3.7.5",
+        "@snf/access-qa-bot": "3.7.3",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -1446,9 +1446,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.5.tgz",
-      "integrity": "sha512-uAL56oLulzdOhBsL9Ac/EKBN6YyR0sy5tg/LMh6XYEjTKfxRiXDwwAGx92fFxom5n3EHWCNXPGIbEEDRPTmLkQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.7.3.tgz",
+      "integrity": "sha512-pM7/5V6/hkK9wO3DfKQ4GljduEvkr7lYueg/TBC19wZa4AiSxoaJRA7XeT5Cp3QtckQTy48KbOVlo2yeIZjkIw==",
       "license": "MIT",
       "dependencies": {
         "@snf/qa-bot-core": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^3.7.5",
+    "@snf/access-qa-bot": "3.7.3",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
Re-points the next `@access-ci/ui` release at the non-agent chatbot (`3.7.3`, exact pin) so npm `latest` no longer defaults to the agent build. The agent build stays published at the exact `0.20.7`/`0.20.8` versions the test multidev pins. Merging publishes `0.20.9` via release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)