### PR TITLE
fix: bump @snf/access-qa-bot to 3.8.2 for embedded chatbot CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@glidejs/glide": "^3.6.1",
-        "@snf/access-qa-bot": "^3.8.0",
+        "@snf/access-qa-bot": "^3.8.2",
         "chart.js": "^4.4.6",
         "fuse.js": "^7.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -1446,9 +1446,9 @@
       ]
     },
     "node_modules/@snf/access-qa-bot": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.8.0.tgz",
-      "integrity": "sha512-StCInVAd07y6mg9y/VaDEjV4dxQ9Wz2ZO/BwVaoAv9Q9I6IV+WjL2j4zS2PdfIhndKAvpAxKWuvgmuTcaxqQnA==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@snf/access-qa-bot/-/access-qa-bot-3.8.2.tgz",
+      "integrity": "sha512-J0RzKGl/KuVMn1tSnd/XpNKC64a5VEh121cndihX16kKlec4cATF9l8BplwAmsDp8Bs82Npj/eJaVBJ0XtC56w==",
       "license": "MIT",
       "dependencies": {
         "@snf/qa-bot-core": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.6.1",
-    "@snf/access-qa-bot": "^3.8.0",
+    "@snf/access-qa-bot": "^3.8.2",
     "chart.js": "^4.4.6",
     "fuse.js": "^7.0.0",
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
Picks up access-qa-bot 3.8.2, which restores the full library stylesheet. The embedded full-width rule was dropped in 3.8.0's partial CSS, so the embedded chatbot rendered narrow instead of filling its container.